### PR TITLE
Single Item Arrays should perform like multiple item arrays

### DIFF
--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -47,7 +47,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     end
 
     # Skip filtering if splitting this event resulted in only one thing found.
-    return if splits.length == 1
+    return if splits.length == 1 && original_value.is_a?(String)
     #or splits[1].empty?
 
     splits.each do |value|

--- a/spec/filters/split_spec.rb
+++ b/spec/filters/split_spec.rb
@@ -75,6 +75,11 @@ describe LogStash::Filters::Split do
       insist { subject[1]["array"] } == "bird"
       insist { subject[2]["array"] } == "sesame street"
     end
+
+    sample("array" => ["big"], "untouched" => "1\n2\n3") do
+      insist { subject.is_a?(Logstash::Event) }
+      insist { subject["array"] } == "big"
+    end
   end
 
   describe "split array into new field" do


### PR DESCRIPTION
I use json parsing for log bodies, and then I split these items out to become separate messages. I have a log line like:

> Jan  5 18:00:00 CLOUDSERVER ui[14253]: Telemetry_JSON[RM7TT15WMLU9bDz8OV_3Vg]: line 1/1 {"metrics": ["servers.server1.snmp.devices.app01.cpu.1.1.1.1 2872 1452016719\n"], "user": ""}

After I json parse the `{.*}`, I run `split` on "metrics" and then run `csv` on each item in "metrics" to split out the items into a new event to output to `elasticsearch` and `datadog`. I feel like a single item array should be treated like a multi-item array. An array with a single item doesn't seem like it should just ignore the array.