### PR TITLE
Allow hashes to merge with existing content

### DIFF
--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -72,16 +72,16 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     if original_value.is_a?(Array)
       splits = original_value
     elsif original_value.is_a?(String)
-      # Using -1 for 'limit' on String#split makes ruby not drop trailing empty
-      # splits.
+      # Using -1 for 'limit' on String#split makes ruby not drop trailing empty splits.
       splits = original_value.split(@terminator, -1)
     else
-      raise LogStash::ConfigurationError, "Only String and Array types are splittable. field:#{@field} is of type = #{original_value.class}"
+      @logger.warn "Only String and Array types are splittable. " \
+                   "Field #{@field} is of type #{original_value.class}."
+      return
     end
 
     # Skip filtering if splitting this event resulted in only one thing found.
     return if splits.length == 1 && original_value.is_a?(String)
-    #or splits[1].empty?
 
     splits.each_with_index do |value, index|
       next if value.empty?
@@ -108,7 +108,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
 
       filter_matched(event_split)
 
-      # Push this new event onto the stack at the LogStash::FilterWorker
+      # Push this new event onto the stack at the LogStash::FilterWorker.
       yield event_split
     end
 

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -89,7 +89,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
       @logger.debug("Split event", :value => value, :field => @field)
 
       if @merge_hash and can_merge_root? value
-        event_split.append(value)
+        LogStash::Util.hash_merge(event_split.to_hash, value)
       else
         if @merge_hash and can_merge_target? value
           value = event_split.get(@target || @field).merge(value)

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -45,7 +45,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
   private
   def should_merge_target?(value)
     # Merge target with hash if merge_hash is set to true and target isn't source.
-    value.is_a? Hash and @merge_hash and (@target || @field) != @field
+    value.is_a? Hash and @merge_hash and @target and @target != @field
   end
 
   public

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -83,7 +83,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     return if splits.length == 1 && original_value.is_a?(String)
     #or splits[1].empty?
 
-    splits.each do |value|
+    splits.each_with_index do |value, index|
       next if value.empty?
 
       event_split = event.clone
@@ -101,6 +101,10 @@ class LogStash::Filters::Split < LogStash::Filters::Base
       if @delete_field and can_delete_field?
         event_split.remove(@field)
       end
+
+      event_split.set("@metadata", {
+        "split_index" => index + 1
+      })
 
       filter_matched(event_split)
 

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -92,11 +92,10 @@ class LogStash::Filters::Split < LogStash::Filters::Base
       if @merge_hash and can_merge_root? value
         event_split.append(value)
       else
-        output_field = (@target || @field)
         if @merge_hash and can_merge_target? value
-          value = event_split.get(output_field).merge(value)
+          value = event_split.get(@target || @field).merge(value)
         end
-        event_split.set(output_field, value)
+        event_split.set(@target || @field, value)
       end
 
       if @delete_field and can_delete_field?

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -75,8 +75,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
       # Using -1 for 'limit' on String#split makes ruby not drop trailing empty splits.
       splits = original_value.split(@terminator, -1)
     else
-      @logger.warn "Only String and Array types are splittable. " \
-                   "Field #{@field} is of type #{original_value.class}."
+      @logger.warn "Only String and Array types are splittable.", field: @field, type: original_value.class, event: event
       return
     end
 

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -89,11 +89,10 @@ class LogStash::Filters::Split < LogStash::Filters::Base
       event_split = event.clone
       @logger.debug("Split event", :value => value, :field => @field)
 
-      output_field = (@target || @field)
-
       if @merge_hash and can_merge_root? value
         event_split.append(value)
       else
+        output_field = (@target || @field)
         if @merge_hash and can_merge_target? value
           value = event_split.get(output_field).merge(value)
         end

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -40,15 +40,15 @@ class LogStash::Filters::Split < LogStash::Filters::Base
   end # def register
 
   private
-  def should_merge_root?(value)
-    # Merge root with hash if merge_hash is set to true and target field haven't been specified.
-    value.is_a? Hash and @merge_hash and @target.nil?
+  def can_merge_root?(value)
+    # Merge root with hash if target field haven't been specified.
+    value.is_a? Hash and @target.nil?
   end
 
   private
-  def should_merge_target?(value)
-    # Merge target with hash if merge_hash is set to true and target isn't source.
-    value.is_a? Hash and @merge_hash and @target and @target != @field
+  def can_merge_target?(value)
+    # Merge target with hash if target isn't source.
+    value.is_a? Hash and @target and @target != @field
   end
 
   private
@@ -91,10 +91,10 @@ class LogStash::Filters::Split < LogStash::Filters::Base
 
       output_field = (@target || @field)
 
-      if should_merge_root? value
+      if @merge_hash and can_merge_root? value
         event_split.append(value)
       else
-        if should_merge_target? value
+        if @merge_hash and can_merge_target? value
           value = event_split.get(output_field).merge(value)
         end
         event_split.set(output_field, value)

--- a/spec/filters/split_spec.rb
+++ b/spec/filters/split_spec.rb
@@ -20,7 +20,7 @@ describe LogStash::Filters::Split do
     end
   end
 
-  describe "custome terminator" do
+  describe "custom terminator" do
     config <<-CONFIG
       filter {
         split {
@@ -34,6 +34,23 @@ describe LogStash::Filters::Split do
       insist { subject[0]["message"] } == "big"
       insist { subject[1]["message"] } == "bird"
       insist { subject[2]["message"] } == "sesame street"
+    end
+  end
+
+  describe "check metadata of clones" do
+    config <<-CONFIG
+      filter {
+        split { }
+      }
+    CONFIG
+
+    sample "one\ntwo\nthree" do
+      insist { subject[0]["message"] } == "one"
+      insist { subject[0]["[@metadata][split_index]"] } == 1
+      insist { subject[1]["message"] } == "two"
+      insist { subject[1]["[@metadata][split_index]"] } == 2
+      insist { subject[2]["message"] } == "three"
+      insist { subject[2]["[@metadata][split_index]"] } == 3
     end
   end
 

--- a/spec/filters/split_spec.rb
+++ b/spec/filters/split_spec.rb
@@ -196,6 +196,10 @@ describe LogStash::Filters::Split do
       insist { subject[1]["custom"] } == "bird"
       insist { subject[2]["custom"] } == "sesame street"
     end
+
+    sample("custom" => 1) do
+      insist { subject.get("custom") } == 1
+    end
   end
 
   describe "split array" do
@@ -238,14 +242,6 @@ describe LogStash::Filters::Split do
       insist { subject[0]["element"] } == "big"
       insist { subject[1]["element"] } == "bird"
       insist { subject[2]["element"] } == "sesame street"
-    end
-  end
-
-  context "when invalid type is passed" do
-    it "should raise exception" do
-      filter = LogStash::Filters::Split.new({"field" => "field"})
-      event = LogStash::Event.new("field" => 10)
-      expect {filter.filter(event)}.to raise_error(LogStash::ConfigurationError)
     end
   end
 end


### PR DESCRIPTION
This PR adds two new config options: `merge_hash` and `delete_field`, both options default to false and are backwards compatible.

Splitting a list of hashes and merging them into `target` or the root is very powerful. For me this solves the question how to bulk events into one and still being able to extract them as separate in Logstash.

Merging a hash into root or `target` will overwrite conflicting keys. Merging a hash into the source field will wipe the field first. `delete_field` can be used without merge as well.
## Root merge example

Config:

```
filter {
  split {
    field => "events"
    merge_hash => true
  }
}
```

Input:

```
{"events": [{"id": 1}, {"id": 2}]}
```

Output:

```
{"id": 1, "events": [{"id": 1}, {"id": 2}]}
{"id": 2, "events": [{"id": 1}, {"id": 2}]}
```
## Root merge and delete source field example

Config:

```
filter {
  split {
    field => "events"
    merge_hash => true
    delete_field => true
  }
}
```

Input:

```
{"events": [{"id": 1}, {"id": 2}]}
```

Output:

```
{"id": 1}
{"id": 2}
```
## Merge with target and delete source field example

Config:

```
filter {
  split {
    field => "events"
    target => "item"
    merge_hash => true
    delete_field => true
  }
}
```

Input:

```
{"events": [{"id": 1}, {"id": 2}]}
```

Output:

```
{"item": {"id": 1}}
{"item": {"id": 2}}
```

I'm happy to port this to `master` as well if it's accepted.
Resolves logstash-plugins/logstash-filter-split#16.
