### PR TITLE
Improve Clone performance on Split

### DIFF
--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -70,7 +70,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     original_value = event.get(@field)
 
     if original_value.is_a?(Array)
-      splits = original_value
+      splits = target.nil? ? event.remove(@field) : original_value
     elsif original_value.is_a?(String)
       # Using -1 for 'limit' on String#split makes ruby not drop trailing empty
       # splits.


### PR DESCRIPTION
Performance is very degraded when we're splitting objects with big arrays

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
