### PR TITLE
fix for numeric values and avoid @target verification, some cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.7
+  - Fixed numeric values, optimized @target verification, cleanups and specs [36](https://github.com/logstash-plugins/logstash-filter-split/pull/36)
+
 ## 3.1.6
   - Fix crash on arrays with null values
 

--- a/logstash-filter-split.gemspec
+++ b/logstash-filter-split.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-split'
-  s.version         = '3.1.6'
+  s.version         = '3.1.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Splits multi-line messages into distinct events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/split_spec.rb
+++ b/spec/filters/split_spec.rb
@@ -122,6 +122,42 @@ describe LogStash::Filters::Split do
     end
   end
 
+  describe "split array of numerics" do
+    config <<-CONFIG
+      filter {
+        split {
+          field => "array"
+          target => "element"
+        }
+      }
+    CONFIG
+
+    sample("array" => [1, 2, 3]) do
+      insist { subject.length } == 3
+      insist { subject[0].get("element") } == 1
+      insist { subject[1].get("element") } == 2
+      insist { subject[2].get("element") } == 3
+    end
+  end
+
+  describe "split array of numerics and strings" do
+    config <<-CONFIG
+      filter {
+        split {
+          field => "array"
+          target => "element"
+        }
+      }
+    CONFIG
+
+    sample("array" => [1, 2, "three", ""]) do
+      insist { subject.length } == 3
+      insist { subject[0].get("element") } == 1
+      insist { subject[1].get("element") } == 2
+      insist { subject[2].get("element") } == "three"
+    end
+  end
+
   context "when invalid type is passed" do
     let(:filter) { LogStash::Filters::Split.new({"field" => "field"}) }
     let(:logger) { filter.logger }


### PR DESCRIPTION
Fixes #13 

The following example was crashing because of numeric values
```sh
$ bin/logstash -e 'input {stdin {codec => json_lines}} filter{split{field => "a"}} output{stdout {codec => rubydebug}}'
...
{"a":[1,2,3]}
```

This PR fixed the numeric case and also adds an optimization to avoid checking for `@target` for every   cloned events. Also adds corresponding specs.