### PR TITLE
Move assignment of event target outside of register

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,9 @@ matrix:
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=master
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=7.0
+    env: LOGSTASH_BRANCH=7.5
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=6.7
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.6
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.0
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6
   fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 3.1.8 Fixed issue where @target optimization would stop event.remove(@field) from being called, which can be expensive with large split fields. [#40](https://github.com/logstash-plugins/logstash-filter-split/pull/40)
+
 ## 3.1.7
-  - Fixed numeric values, optimized @target verification, cleanups and specs [36](https://github.com/logstash-plugins/logstash-filter-split/pull/36)
+  - Fixed numeric values, optimized @target verification, cleanups and specs [#36](https://github.com/logstash-plugins/logstash-filter-split/pull/36)
 
 ## 3.1.6
   - Fix crash on arrays with null values

--- a/logstash-filter-split.gemspec
+++ b/logstash-filter-split.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-split'
-  s.version         = '3.1.7'
+  s.version         = '3.1.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Splits multi-line messages into distinct events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/split_spec.rb
+++ b/spec/filters/split_spec.rb
@@ -12,6 +12,10 @@ describe LogStash::Filters::Split do
       }
     CONFIG
 
+    sample "big\n" do
+      insist { subject.get("message") } == 'big'
+    end
+
     sample "big\nbird\nsesame street" do
       insist { subject.length } == 3
       insist { subject[0].get("message") } == "big"


### PR DESCRIPTION
The previous assignment of `@target` in the register method would
remove the possibility of event.remove(@field) being called when
setting the `splits` variable, which can have an outsize impact
on performance, causing expensive clone calls when huge fields
are being split
