### PR TITLE
proof: split specs work when validating output not queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
+
+gem 'logstash-devutils', :git => 'https://github.com/yaauie/logstash-devutils.git', :branch => 'sample-logstash-helper-fixes'


### PR DESCRIPTION
This PR proves that https://github.com/elastic/logstash-devutils/pull/97 works by pinning our dependency on logstash-devutils on the branch in question.

It is not meant to be merged, merely to validate in CI.