### PR TITLE
add trace log to track event size expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.10
+  - Added trace log to track event size expansion
+
 ## 3.1.9
   - [DOC] Added introductory statement to clarify purpose of the plugin [#43](https://github.com/logstash-plugins/logstash-filter-split/pull/43)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.10
-  - Added trace log to track event size expansion
+  - Added trace log to track event size expansion [#49](https://github.com/logstash-plugins/logstash-filter-split/pull/49)
 
 ## 3.1.9
   - [DOC] Added introductory statement to clarify purpose of the plugin [#43](https://github.com/logstash-plugins/logstash-filter-split/pull/43)

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -81,6 +81,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
 
     # set event_target to @field if not configured
     event_target = @target.nil? ? @field : @target
+    split_bytes = 0
 
     splits.each do |value|
       next if value.nil? || (value.is_a?(String) && value.empty?)
@@ -90,8 +91,19 @@ class LogStash::Filters::Split < LogStash::Filters::Base
       event_split.set(event_target, value)
       filter_matched(event_split)
 
+      logger.trace? && split_bytes += event_split.to_json.size
+
       # Push this new event onto the stack at the LogStash::FilterWorker
       yield event_split
+    end
+
+
+    if logger.trace?
+      original_bytes = event.to_json.size
+      logger.trace("Event is split into #{splits.size}", 
+        :split_bytes => split_bytes, 
+        :original_bytes => original_bytes, 
+        :ratio => (split_bytes.to_f / original_bytes).round(2))
     end
 
     # Cancel this event, we'll use the newly generated ones above.

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -82,7 +82,8 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     # set event_target to @field if not configured
     event_target = @target.nil? ? @field : @target
     split_bytes = 0
-    logger.trace("Event being split into #{splits.size} events")
+    logger.trace? && logger.trace("Event being split into #{splits.size} events")
+    
     splits.each do |value|
       next if value.nil? || (value.is_a?(String) && value.empty?)
       @logger.debug? && @logger.debug("Split event", :value => value, :field => @field)

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -86,7 +86,6 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     
     splits.each do |value|
       next if value.nil? || (value.is_a?(String) && value.empty?)
-      @logger.debug? && @logger.debug("Split event", :value => value, :field => @field)
 
       event_split = event.clone
       event_split.set(event_target, value)

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -82,7 +82,7 @@ class LogStash::Filters::Split < LogStash::Filters::Base
     # set event_target to @field if not configured
     event_target = @target.nil? ? @field : @target
     split_bytes = 0
-
+    logger.trace("Event being split into #{splits.size} events")
     splits.each do |value|
       next if value.nil? || (value.is_a?(String) && value.empty?)
       @logger.debug? && @logger.debug("Split event", :value => value, :field => @field)

--- a/lib/logstash/filters/split.rb
+++ b/lib/logstash/filters/split.rb
@@ -100,10 +100,10 @@ class LogStash::Filters::Split < LogStash::Filters::Base
 
     if logger.trace?
       original_bytes = event.to_json.size
-      logger.trace("Event is split into #{splits.size}", 
-        :split_bytes => split_bytes, 
-        :original_bytes => original_bytes, 
-        :ratio => (split_bytes.to_f / original_bytes).round(2))
+      logger.trace("Estimated event size growth after split",
+        :original_bytes => original_bytes,
+        :split_bytes => split_bytes,
+        :growth_ratio => (split_bytes.to_f / original_bytes).round(2))
     end
 
     # Cancel this event, we'll use the newly generated ones above.

--- a/logstash-filter-split.gemspec
+++ b/logstash-filter-split.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-split'
-  s.version         = '3.1.9'
+  s.version         = '3.1.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Splits multi-line messages into distinct events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
tested the following pipeline  `bin/logstash -f split.conf --log.level trace`
```
input {
    generator {
        lines => [
            '{"kubernetes" : {"label": {"app": "somevalue" }}, "split": ["1","2","3"] }'
        ]
        count => 1
        codec => json
    }
}
filter { split { field => "split" }}
output { stdout { } }
```

log
```
[2025-11-18T15:29:49,196][TRACE][logstash.filters.split   ][main][e42465377ab12961a4ebbb80634862df2eacd4cc029b3817f2a772eb317df8e7] Event is split into 3 {:split_bytes=>819, :original_bytes=>261, :ratio=>3.14}
```